### PR TITLE
[Fix] Export to workflow when a repository scan fails

### DIFF
--- a/utils/scan.py
+++ b/utils/scan.py
@@ -75,6 +75,8 @@ def scan_repo_report(valid_repos, args):
                 report[config.BASE_CORE_BRANCH_KEY] = {'scan_status': 'done', 'scan_error_message': '--'}
             except Exception as e:
                 report[config.BASE_CORE_BRANCH_KEY] = {'scan_status': 'failed', 'scan_error_message': str(e)}
+                with open(f"{os.getcwd()}/action_result.txt", "a") as workflow_file:
+                    workflow_file.write(f"{repo} - scan failed\n")
 
             # Scan the cloned repo with second branch and push output to a file with debug logs
             second_command = build_command(cwd, config.HEAD_CORE_BRANCH_NAME, config.HEAD_CORE_BRANCH_KEY, scan_dir,

--- a/utils/scan.py
+++ b/utils/scan.py
@@ -102,6 +102,8 @@ def scan_repo_report(valid_repos, args):
                 report[config.HEAD_CORE_BRANCH_KEY] = {'scan_status': 'done', 'scan_error_message': '--'}
             except Exception as e:
                 report[config.HEAD_CORE_BRANCH_KEY] = {'scan_status': 'failed', 'scan_error_message': str(e)}
+                with open(f"{os.getcwd()}/action_result.txt", "a") as workflow_file:
+                    workflow_file.write(f"{repo} - scan failed\n")
             
             scan_report[repo] = report
 

--- a/workflow_check.py
+++ b/workflow_check.py
@@ -23,7 +23,7 @@ def main(filepath):
 
     check = True
 
-    with open(filepath) as summary_report:
+    with open(filepath, "a") as summary_report:
 
         for line in summary_report.readlines():
 


### PR DESCRIPTION
Currently, even though a repository scan fails, the PR is unblocked for merging. This PR aims at stopping this behavior. 